### PR TITLE
Update to Xcode 14.1 / iOS 16.1 

### DIFF
--- a/.github/workflows/CI-iOS.yml
+++ b/.github/workflows/CI-iOS.yml
@@ -22,10 +22,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Select Xcode
-      run: sudo xcode-select -switch /Applications/Xcode_13.3.app
+      run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       
     - name: Xcode version
       run: /usr/bin/xcodebuild -version
       
     - name: Build and Test
-      run: xcodebuild clean build test -workspace EssentialApp/EssentialApp.xcworkspace -scheme "CI_iOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 13,OS=15.4" ONLY_ACTIVE_ARCH=YES
+      run: xcodebuild clean build test -workspace EssentialApp/EssentialApp.xcworkspace -scheme "CI_iOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=16.1" ONLY_ACTIVE_ARCH=YES

--- a/.github/workflows/CI-macOS.yml
+++ b/.github/workflows/CI-macOS.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Select Xcode
-      run: sudo xcode-select -switch /Applications/Xcode_13.3.app
+      run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       
     - name: Xcode version
       run: /usr/bin/xcodebuild -version

--- a/EssentialApp/EssentialAppTests/Helpers/UIImage+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIImage+TestHelpers.swift
@@ -10,12 +10,12 @@ import UIKit
 extension UIImage {
     static func make(withColor color: UIColor) -> UIImage {
         let rect = CGRect(x: 0, y: 0, width: 1, height: 1)
-        UIGraphicsBeginImageContext(rect.size)
-        let context = UIGraphicsGetCurrentContext()!
-        context.setFillColor(color.cgColor)
-        context.fill(rect)
-        let img = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return img!
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        
+        return UIGraphicsImageRenderer(size: rect.size, format: format).image { rendererContext in
+            color.setFill()
+            rendererContext.fill(rect)
+        }
     }
 }


### PR DESCRIPTION
iOS 16.1+ fix: Set explicit test images scale to 1 to ensure they all have the same scale (so their pngData can be compared pixel by pixel)